### PR TITLE
fix: dashboard crash loop on container restart

### DIFF
--- a/build/go/entrypoint/main.go
+++ b/build/go/entrypoint/main.go
@@ -71,21 +71,21 @@ func dashboard(){
 		return nil
 	})
 	if err != nil {
-		eleven.LogFatal("could not start dasshboard!", err)
+		eleven.LogFatal("could not start dashboard!", err)
 	}
 
-	// replace all environment variables in a list of custom files
-	custom := []string{APP_DASHBOARD_TRUSTED_DOMAINS_TEMPLATE}
-	for _, path := range custom {
-		err := eleven.Container.FileContentReplaceEnv(path)
+	// create OidcTrustedDomains.js from tmpl, keep the tmpl so restarts and env changes keep working
+	if info, err := os.Stat(APP_DASHBOARD_TRUSTED_DOMAINS_TEMPLATE); err == nil {
+		text, err := ioutil.ReadFile(APP_DASHBOARD_TRUSTED_DOMAINS_TEMPLATE)
 		if err != nil {
-			eleven.LogFatal("could not setup file %s", path, err)
+			eleven.LogFatal("could not read file %s", APP_DASHBOARD_TRUSTED_DOMAINS_TEMPLATE, err)
 		}
-	}
-
-	// rename tmpl if not already done
-	if _, err := os.Stat(APP_DASHBOARD_TRUSTED_DOMAINS_TEMPLATE); !os.IsNotExist(err) {
-		os.Rename(APP_DASHBOARD_TRUSTED_DOMAINS_TEMPLATE, APP_DASHBOARD_TRUSTED_DOMAINS)
+		if err := ioutil.WriteFile(APP_DASHBOARD_TRUSTED_DOMAINS, text, info.Mode().Perm()); err != nil {
+			eleven.LogFatal("could not setup file %s", APP_DASHBOARD_TRUSTED_DOMAINS, err)
+		}
+		if err := eleven.Container.FileContentReplaceEnv(APP_DASHBOARD_TRUSTED_DOMAINS); err != nil {
+			eleven.LogFatal("could not setup file %s", APP_DASHBOARD_TRUSTED_DOMAINS, err)
+		}
 	}
 
 	// start nginx


### PR DESCRIPTION
> [!NOTE]
> **AI disclosure:** This fix was developed with the help of an AI assistant (Claude Code by Anthropic). The AI analyzed the bug, authored the code changes and this PR description. The changes were reviewed and the fix was verified end-to-end in running containers by a human maintainer before submission.

## Problem

In dashboard mode (`--dashboard`) the entrypoint env-substitutes `/nginx/var/OidcTrustedDomains.js.tmpl` in place and then renames it to `OidcTrustedDomains.js`. With `/nginx/var` on a persistent volume (as in the repo's own `compose.yml`, `dashboard.var:/nginx/var`), the rename is permanent — so on the **second** container start the tmpl no longer exists, `FileContentReplaceEnv` fails with ENOENT and `LogFatal` exits 1. Under `restart: always` this is a permanent crash loop, recoverable only by deleting the volume:

```
{"time":"...","type":"ERR","msg":"could not setup file /nginx/var/OidcTrustedDomains.js.tmpl%!(EXTRA *fs.PathError=open /nginx/var/OidcTrustedDomains.js.tmpl: no such file or directory)"}
```

The existing `os.Stat` guard only protects the rename, which runs *after* the substitution that crashes.

## Fix

If the tmpl exists, copy it to `OidcTrustedDomains.js` (inheriting the tmpl's permission bits) and run the env substitution on the copy — the template is never consumed. This also means changes to `NETBIRD_MGMT_API_ENDPOINT` / `NETBIRD_MGMT_GRPC_API_ENDPOINT` are re-applied on every start instead of being frozen at first boot. Volumes created by the current code (tmpl already renamed away) skip the block and boot normally, keeping their existing `OidcTrustedDomains.js`.

Also fixes the "dasshboard" typo in the fatal log message.

## Testing

Static build (`CGO_ENABLED=0`, go-eleven v0.4.4 as pinned) run in containers against a volume seeded like the published `11notes/netbird:0.74.7` image:

| Scenario | current code | this PR |
| --- | --- | --- |
| First boot (tmpl present) | ✅ | ✅ tmpl kept, `OidcTrustedDomains.js` generated |
| Restart, same volume | ❌ exit 1, crash loop | ✅ |
| Restart with changed `NETBIRD_MGMT_*` | ❌ (already crashed) | ✅ values re-substituted |
| Volume from current image (tmpl gone, .js present) | ❌ crash loop | ✅ block skipped, boots |

File modes verified against the published image (`-rw-r--r--`, 1000:1000): the generated file gets the same mode the rename used to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)